### PR TITLE
Add AP-AC-EDU Support

### DIFF
--- a/UniFiSharp/IUniFiRestClient.cs
+++ b/UniFiSharp/IUniFiRestClient.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Globalization;
 using System.Threading.Tasks;
 
 namespace UniFiSharp
@@ -89,6 +90,8 @@ namespace UniFiSharp
         /// <param name="url">URL to operate on</param>
         /// <returns></returns>
         Task UniFiDelete(string url);
+
+        Task UnifiFileUpload(string url, string name, string fileName, string contentType, byte[] data);
 
         /// <summary>
         /// Authenticate to the UniFi controller

--- a/UniFiSharp/Json/JsonBroadcastDevice.cs
+++ b/UniFiSharp/Json/JsonBroadcastDevice.cs
@@ -1,0 +1,9 @@
+﻿namespace UniFiSharp.Json
+{
+    public class JsonBroadcastDevice
+    {
+        public bool connected { get; set; }
+        public string mac { get; set; }
+        public long volume { get; set; }
+    }
+}

--- a/UniFiSharp/Json/JsonBroadcastGroup.cs
+++ b/UniFiSharp/Json/JsonBroadcastGroup.cs
@@ -1,0 +1,13 @@
+﻿namespace UniFiSharp.Json
+{
+    public class JsonBroadcastGroup
+    {
+        public string _id { get; set; }
+        public string site_id { get; set; }
+        public string name { get; set; }
+        public string[] member_table { get; set; }
+        public string attr_hidden_id { get; set; }
+        public bool attr_no_delete { get; set; }
+        public bool attr_no_edit { get; set; }
+    }
+}

--- a/UniFiSharp/Json/JsonMediaFile.cs
+++ b/UniFiSharp/Json/JsonMediaFile.cs
@@ -1,0 +1,16 @@
+﻿namespace UniFiSharp.Json
+{
+    public class JsonMediaFile
+    {
+        public string _id { get; set; }
+        public string site_id { get; set; }
+        public string filename { get; set; }
+        public int filesize { get; set; }
+        public string content_type { get; set; }
+        public int last_modified { get; set; }
+        public string md5 { get; set; }
+        public string name { get; set; }
+        public int length { get; set; }
+        public string url { get; set; }
+    }
+}

--- a/UniFiSharp/Json/JsonNetworkDevice.cs
+++ b/UniFiSharp/Json/JsonNetworkDevice.cs
@@ -193,6 +193,9 @@ namespace UniFiSharp.Json
         [JsonProperty("has_speaker")]
         public bool? has_speaker { get; set; }
 
+        [JsonProperty("volume")]
+        public int volume { get; set; }
+
         [JsonProperty("isolated")]
         public bool? isolated { get; set; }
 

--- a/UniFiSharp/Json/JsonSampleMedia.cs
+++ b/UniFiSharp/Json/JsonSampleMedia.cs
@@ -1,0 +1,7 @@
+﻿namespace UniFiSharp.Json
+{
+    public class JsonSampleMedia
+    {
+        public string sample_filename { get; set; }
+    }
+}

--- a/UniFiSharp/Json/JsonStreamInfo.cs
+++ b/UniFiSharp/Json/JsonStreamInfo.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+
+namespace UniFiSharp.Json
+{
+    public class JsonStreamInfo
+    {
+        public bool autostart { get; set; } = false;
+        public string broadcastgroup_id { get; set; }
+        public long channel { get; set; } = 1;
+        public string cmd { get; set; } = "create-stream";
+        public List<JsonBroadcastDevice> devices { get; set; } = new List<JsonBroadcastDevice>();
+        public string iv { get; set; }
+        public string key { get; set; }
+        public string mediafile_id { get; set; }
+        public long quality { get; set; } = 4;
+        public long rate { get; set; } = 48000;
+        public string sample_filename { get; set; }
+        public string type { get; set; } = "media";
+        public string url { get; set; }
+    }
+}

--- a/UniFiSharp/Json/JsonStreamStatus.cs
+++ b/UniFiSharp/Json/JsonStreamStatus.cs
@@ -8,5 +8,6 @@
         public JsonNetworkDevice[] devices { get; set; }
         public string type { get; set; }
         public string sample_filename { get; set; }
+        public string mediafile_id { get; set; }
     }
 }

--- a/UniFiSharp/Json/JsonStreamStatus.cs
+++ b/UniFiSharp/Json/JsonStreamStatus.cs
@@ -1,0 +1,12 @@
+﻿namespace UniFiSharp.Json
+{
+    public class JsonStreamStatus
+    {
+        public string streamId { get; set; }
+        public bool ready { get; set; }
+        public bool streaming { get; set; }
+        public JsonNetworkDevice[] devices { get; set; }
+        public string type { get; set; }
+        public string sample_filename { get; set; }
+    }
+}

--- a/UniFiSharp/Orchestration/Devices/IInfrastructureNetworkedDevice.cs
+++ b/UniFiSharp/Orchestration/Devices/IInfrastructureNetworkedDevice.cs
@@ -83,6 +83,9 @@ namespace UniFiSharp.Orchestration.Devices
         public List<IClientNetworkedDevice> Clients { get; internal set; }
         public List<IInfrastructureNetworkedDevice> InfrastructureDevices { get; internal set; }
 
+        public bool? HasSpeaker => Json.has_speaker;
+        public int Volume => Json.volume;
+
         protected JsonNetworkDevice Json { get; private set; }
 
         protected IInfrastructureNetworkedDevice(UniFiApi api, JsonNetworkDevice json) : base(api)

--- a/UniFiSharp/UniFiApi.BroadcastGroup.cs
+++ b/UniFiSharp/UniFiApi.BroadcastGroup.cs
@@ -1,0 +1,71 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using UniFiSharp.Json;
+
+namespace UniFiSharp
+{
+    public partial class UniFiApi
+    {
+		// This partial class is for management of Broadcast Groups. These are used for simultaneously broadcasting streams to groups of UniFI EDU APs
+
+		/// <summary>
+        /// Get all broadcast groups on the controller
+        /// </summary>
+        /// <returns>Collection of JSON objects containing the broadcast groups and devices in each group</returns>
+        public async Task<IEnumerable<JsonBroadcastGroup>> BroadcastGroupList()
+        {
+            return await RestClient.UniFiGetMany<JsonBroadcastGroup>($"api/s/{Site}/rest/broadcastgroup");
+        }
+
+		/// <summary>
+        /// Retrieve info about a single broadcast group
+        /// </summary>
+        /// <param name="groupId">ID of the group to query</param>
+        /// <returns>JSON object describing the group and listing the devices in the group</returns>
+        public async Task<JsonBroadcastGroup> BroadcastGroupGet(string groupId)
+        {
+            return await RestClient.UniFiGet<JsonBroadcastGroup>($"api/s/{Site}/rest/broadcastgroup/{groupId}");
+        }
+
+		/// <summary>
+        /// Delete a broadcast group
+        /// </summary>
+        /// <param name="groupId">ID of the broadcast group</param>
+        /// <returns></returns>
+        public async Task BroadcastGroupDelete(string groupId)
+        {
+            await RestClient.UniFiDelete($"api/s/{Site}/rest/broadcastgroup/{groupId}");
+        }
+
+		/// <summary>
+        /// Create a new broadcast group
+        /// </summary>
+        /// <param name="groupName">Name of the broadcast group</param>
+        /// <param name="memberTable">MAC addresses of the devices to include in the group</param>
+        /// <returns>JSON object containing details of the created group</returns>
+        public async Task<JsonBroadcastGroup> BroadcastGroupCreate(string groupName, string[] memberTable)
+        {
+            return await RestClient.UniFiPost<JsonBroadcastGroup>($"api/s/{Site}/rest/broadcastgroup", new
+            {
+				name = groupName,
+				member_table = memberTable
+            });
+        }
+
+        /// <summary>
+        /// Update an existing broadcast group
+        /// </summary>
+        /// <param name="groupId">ID of the group to update</param>
+        /// <param name="groupName">Name of the broadcast group</param>
+        /// <param name="memberTable">MAC addresses of the devices to include in the group</param>
+        /// <returns></returns>
+        public async Task<JsonBroadcastGroup> BroadcastGroupUpdate(string groupId, string groupName, string[] memberTable)
+        {
+            return await RestClient.UniFiPut<JsonBroadcastGroup>($"api/s/{Site}/rest/broadcastgroup/{groupId}", new
+            {
+                name = groupName,
+                member_table = memberTable
+            });
+        }
+    }
+}

--- a/UniFiSharp/UniFiApi.Media.cs
+++ b/UniFiSharp/UniFiApi.Media.cs
@@ -38,13 +38,14 @@ namespace UniFiSharp
 
 
         /// <summary>
-        /// Uploads a media file to the UniFi controller. Note that OGG files are the only known supported file type (recommended quality 4)
+        /// Uploads a media file to the UniFi controller. Note that OGG files are the only known supported file type (recommended quality 4).
+        /// Other audio formats will upload but cannot be played by AP-AC-EDU devices
         /// </summary>
         /// <param name="name">Human readable name for the file</param>
         /// <param name="fileData">Byte array containing the file data</param>
         /// <param name="fileName">Optional file name for internal use</param>
         /// <returns></returns>
-        public async Task MediaFileCreate(string name, byte[] fileData, string fileName = "")
+        public async Task MediaFileCreate(string name, byte[] fileData, string fileName = "", string contentType = "audio/ogg")
         {
             // If no custom filename is specified, then set the filename to the current date/time
             if (string.IsNullOrWhiteSpace(fileName))
@@ -52,7 +53,7 @@ namespace UniFiSharp
                 fileName = DateTime.Now.ToString("s") + ".ogg";
             }
 
-            await RestClient.UnifiFileUpload($"/upload/s/{Site}/mediafile", name, fileName, "audio/ogg", fileData);
+            await RestClient.UnifiFileUpload($"/upload/s/{Site}/mediafile", name, fileName, contentType, fileData);
         }
 
         /// <summary>

--- a/UniFiSharp/UniFiApi.Media.cs
+++ b/UniFiSharp/UniFiApi.Media.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using UniFiSharp.Json;
+
+namespace UniFiSharp
+{
+    public partial class UniFiApi
+    {
+        // Partial class for managing media files on the UniFi controller. These files can then be streamed to supported devices (e.g. UniFi EDU APs)
+
+        /// <summary>
+        /// Retrieves all the media files uploaded to the controller
+        /// </summary>
+        /// <returns>Collection of JSON objects describing media files stored on this controller</returns>
+        public async Task<IEnumerable<JsonMediaFile>> MediaFileList()
+        {
+            return await RestClient.UniFiGetMany<JsonMediaFile>($"api/s/{Site}/rest/mediafile");
+        }
+
+        /// <summary>
+        /// Retrieves a specific file uploaded to the controller
+        /// </summary>
+        /// <returns>Collection of JSON objects describing media files stored on this controller</returns>
+        public async Task<JsonMediaFile> MediaFileGet(string fileId)
+        {
+            return await RestClient.UniFiGet<JsonMediaFile>($"api/s/{Site}/rest/mediafile/{fileId}");
+        }
+
+        /// <summary>
+        /// Deletes a specific uploaded media file from the controller
+        /// </summary>
+        /// <returns>Collection of JSON objects describing sample media files stored on this controller</returns>
+        public async Task MediaFileDelete(string fileId)
+        {
+            await RestClient.UniFiDelete($"api/s/{Site}/rest/mediafile/{fileId}");
+        }
+
+
+        /// <summary>
+        /// Uploads a media file to the UniFi controller. Note that OGG files are the only known supported file type (recommended quality 4)
+        /// </summary>
+        /// <param name="name">Human readable name for the file</param>
+        /// <param name="fileData">Byte array containing the file data</param>
+        /// <param name="fileName">Optional file name for internal use</param>
+        /// <returns></returns>
+        public async Task MediaFileCreate(string name, byte[] fileData, string fileName = "")
+        {
+            // If no custom filename is specified, then set the filename to the current date/time
+            if (string.IsNullOrWhiteSpace(fileName))
+            {
+                fileName = DateTime.Now.ToString("s") + ".ogg";
+            }
+
+            await RestClient.UnifiFileUpload($"/upload/s/{Site}/mediafile", name, fileName, "audio/ogg", fileData);
+        }
+
+        /// <summary>
+        /// Retrieves all the sample media files on the controller
+        /// </summary>
+        /// <returns>Collection of JSON objects describing sample media files stored on this controller</returns>
+        public async Task<IEnumerable<JsonSampleMedia>> SampleFileList()
+        {
+            return await RestClient.UniFiPostMany<JsonSampleMedia>($"api/s/{Site}/cmd/streammgr/list-samples", new
+            {
+                cmd = "list-samples"
+            });
+        }
+
+
+    }
+}

--- a/UniFiSharp/UniFiApi.NetworkDevices.cs
+++ b/UniFiSharp/UniFiApi.NetworkDevices.cs
@@ -142,5 +142,21 @@ namespace UniFiSharp
         {
             await RestClient.UniFiPost($"api/s/{Site}/cmd/devmgr/upgrade", new { mac = macAddress });
         }
+
+        /// <summary>
+        /// Set the volume of the device's speaker
+        /// </summary>
+        /// <param name="macAddress">Device MAC Address</param>
+        /// <param name="volume">Volume to set the speaker to (range 0 - 100)</param>
+        /// <returns></returns>
+        public async Task NetworkDeviceSetVolume(string macAddress, int volume)
+        {
+            await RestClient.UniFiPost($"api/s/{Site}/cmd/streammgr/set-volume", new
+            {
+                cmd = "set-volume",
+                mac = macAddress,
+                volume = volume
+            });
+        }
     }
 }

--- a/UniFiSharp/UnifiApi.Stream.cs
+++ b/UniFiSharp/UnifiApi.Stream.cs
@@ -60,10 +60,7 @@ namespace UniFiSharp
                 streamId = streamId
             });
         }
-
-
-
-
+        
         public async Task<IEnumerable<JsonStreamStatus>> ActiveStreamList()
         {
             return await RestClient.UniFiGetMany<JsonStreamStatus>($"api/s/{Site}/stat/stream");

--- a/UniFiSharp/UnifiApi.Stream.cs
+++ b/UniFiSharp/UnifiApi.Stream.cs
@@ -1,0 +1,72 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using UniFiSharp.Json;
+
+namespace UniFiSharp
+{
+    public partial class UniFiApi
+    {
+        // This partial class is for managing media streams, typically to UniFi EDU APs
+
+        /// <summary>
+        /// Plays a sample file on a specific access point.
+        /// </summary>
+        /// <returns>Collection of JSON objects describing sample media files stored on this controller</returns>
+        public async Task<IEnumerable<JsonStreamStatus>> SampleStreamStart(string filename, string macAddress)
+        {
+            return await RestClient.UniFiPostMany<JsonStreamStatus>($"api/s/{Site}/cmd/streammgr/sample-stream", new
+            {
+                cmd = "sample-stream",
+                mac = macAddress,
+                sample_filename = filename
+            });
+        }
+
+
+        /// <summary>
+        /// Creates a stream with the specified options. 
+        /// </summary>
+        /// <param name="streamInfo">Options for the specified stream, such as broadcast group and file</param>
+        /// <returns>Details of the created stream</returns>
+        public async Task<JsonStreamStatus> StreamCreate(JsonStreamInfo streamInfo)
+        {
+            return await RestClient.UniFiPost<JsonStreamStatus>($"api/s/{Site}/cmd/streammgr/create-stream", streamInfo);
+        }
+
+        /// <summary>
+        /// Stops a stream with a given ID
+        /// </summary>
+        /// <param name="streamId">ID of the stream to start</param>
+        /// <returns>Status of the stopped stream</returns>
+        public async Task<JsonStreamStatus> StreamStop(string streamId)
+        {
+            return await RestClient.UniFiPost<JsonStreamStatus>($"api/s/{Site}/cmd/streammgr/stop-stream", new
+            {
+                cmd = "stop-stream",
+                streamId = streamId
+            });
+        }
+
+        /// <summary>
+        /// Starts a stream with a given ID
+        /// </summary>
+        /// <param name="streamId">ID of the stream to start</param>
+        /// <returns>Status of the started stream</returns>
+        public async Task<JsonStreamStatus> StreamStart(string streamId)
+        {
+            return await RestClient.UniFiPost<JsonStreamStatus>($"api/s/{Site}/cmd/streammgr/start-stream", new
+            {
+                cmd = "start-stream",
+                streamId = streamId
+            });
+        }
+
+
+
+
+        public async Task<IEnumerable<JsonStreamStatus>> ActiveStreamList()
+        {
+            return await RestClient.UniFiGetMany<JsonStreamStatus>($"api/s/{Site}/stat/stream");
+        }
+    }
+}


### PR DESCRIPTION
Add a selection of API functions and update Orchestrator accordingly to add support for the [UniFi AP-AC-EDU](https://www.ui.com/unifi/unifi-ap-ac-edu/) access points which have built in speakers. 

Adds the ability to upload and manage audio files in the UniFi controller, manage active streams, manage broadcast groups and start streams to devices and broadcast groups.