### PR TITLE
Integer overflow fix & add device states

### DIFF
--- a/UniFiSharp/Json/JsonClient.cs
+++ b/UniFiSharp/Json/JsonClient.cs
@@ -48,7 +48,7 @@ namespace UniFiSharp.Json
         public string bssid { get; set; }
 
         [JsonProperty("bytes-r")]
-        public int bytes_r { get; set; }
+        public long bytes_r { get; set; }
 
         [JsonProperty("ccq")]
         public int ccq { get; set; }

--- a/UniFiSharp/Json/JsonNetworkDevice.cs
+++ b/UniFiSharp/Json/JsonNetworkDevice.cs
@@ -182,7 +182,7 @@ namespace UniFiSharp.Json
         public int? bytes_d { get; set; }
 
         [JsonProperty("bytes-r")]
-        public int? bytes_r { get; set; }
+        public long? bytes_r { get; set; }
 
         [JsonProperty("downlink_table")]
         public IList<JsonLink> downlink_table { get; set; }
@@ -484,7 +484,7 @@ namespace UniFiSharp.Json
             public long tx_bytes { get; set; }
 
             [JsonProperty("tx_packets")]
-            public int tx_packets { get; set; }
+            public long tx_packets { get; set; }
 
             [JsonProperty("up")]
             public bool up { get; set; }
@@ -589,7 +589,7 @@ namespace UniFiSharp.Json
             public int tx_errors { get; set; }
 
             [JsonProperty("tx_packets")]
-            public int tx_packets { get; set; }
+            public long tx_packets { get; set; }
 
             [JsonProperty("up")]
             public bool up { get; set; }
@@ -604,7 +604,7 @@ namespace UniFiSharp.Json
             public bool? autoneg { get; set; }
 
             [JsonProperty("bytes-r")]
-            public int? bytes_r { get; set; }
+            public long? bytes_r { get; set; }
 
             [JsonProperty("flowctrl_rx")]
             public bool? flowctrl_rx { get; set; }
@@ -646,7 +646,7 @@ namespace UniFiSharp.Json
             public int? rx_broadcast { get; set; }
 
             [JsonProperty("rx_bytes-r")]
-            public int? rx_bytes_r { get; set; }
+            public long? rx_bytes_r { get; set; }
 
             [JsonProperty("stp_pathcost")]
             public int? stp_pathcost { get; set; }
@@ -658,7 +658,7 @@ namespace UniFiSharp.Json
             public int? tx_broadcast { get; set; }
 
             [JsonProperty("tx_bytes-r")]
-            public int? tx_bytes_r { get; set; }
+            public long? tx_bytes_r { get; set; }
 
             [JsonProperty("tx_multicast")]
             public int? tx_multicast { get; set; }
@@ -772,7 +772,7 @@ namespace UniFiSharp.Json
         public class JsonLink
         {
             [JsonProperty("bytes-r")]
-            public int bytes_r { get; set; }
+            public long bytes_r { get; set; }
 
             [JsonProperty("drops")]
             public int drops { get; set; }
@@ -841,10 +841,10 @@ namespace UniFiSharp.Json
             public string speedtest_status { get; set; }
 
             [JsonProperty("tx_bytes")]
-            public object tx_bytes { get; set; }
+            public long tx_bytes { get; set; }
 
             [JsonProperty("tx_bytes-r")]
-            public int tx_bytes_r { get; set; }
+            public long tx_bytes_r { get; set; }
 
             [JsonProperty("tx_dropped")]
             public int tx_dropped { get; set; }
@@ -853,7 +853,7 @@ namespace UniFiSharp.Json
             public int tx_errors { get; set; }
 
             [JsonProperty("tx_packets")]
-            public int tx_packets { get; set; }
+            public long tx_packets { get; set; }
 
             [JsonProperty("type")]
             public string type { get; set; }
@@ -1021,7 +1021,7 @@ namespace UniFiSharp.Json
             public int tx_errors { get; set; }
 
             [JsonProperty("tx_packets")]
-            public int tx_packets { get; set; }
+            public long tx_packets { get; set; }
 
             [JsonProperty("tx_power")]
             public int tx_power { get; set; }

--- a/UniFiSharp/Orchestration/Devices/IInfrastructureNetworkedDevice.cs
+++ b/UniFiSharp/Orchestration/Devices/IInfrastructureNetworkedDevice.cs
@@ -65,7 +65,7 @@ namespace UniFiSharp.Orchestration.Devices
         public int HandheldClientCount => Json.num_handheld;
         public int ClientCount => Json.num_sta;
 
-        public DeviceLink Uplink => new DeviceLink(Json.uplink);
+        public DeviceLink Uplink => Json.uplink != null ? new DeviceLink(Json.uplink) : null;
 
         public double[] LoadAverage => new double[] {
             Json.sys_stats.loadavg_1.GetValueOrDefault(-1),

--- a/UniFiSharp/Orchestration/Devices/IInfrastructureNetworkedDevice.cs
+++ b/UniFiSharp/Orchestration/Devices/IInfrastructureNetworkedDevice.cs
@@ -9,15 +9,22 @@ namespace UniFiSharp.Orchestration.Devices
     {
         public enum NetworkDeviceState
         {
+            Adopting,
             AdoptionFailed,
             Disconnected,
             Connected,
+            Deleting,
+            FirmwareMismatch,
+            HeartbeatMissed,
+            Isolated,
+            PendingApproval,
+            Upgrading,
             Unadopted,
             Inaccessible,
             Provisioning,
             RfScanning,
             Unknown
-        };
+        }
 
         public NetworkDeviceState StateEnum
         {
@@ -26,22 +33,34 @@ namespace UniFiSharp.Orchestration.Devices
                 switch (this.State)
                 {
                     case 0:
-                        return NetworkDeviceState.Disconnected;
+                        return NetworkDeviceState.Disconnected; // According to the UniFi app, 0 represents restarting although this does not reflect real-world testing where 0 = Disconnected.
 
                     case 1:
                         return NetworkDeviceState.Connected;
 
                     case 2:
                         if (this.UsingDefaultSettings) // if we're not on default settings, the controller can't adopt
-                            return NetworkDeviceState.Unadopted;
+                            return NetworkDeviceState.PendingApproval;
                         else
                             return NetworkDeviceState.Inaccessible;
-
+                    case 3:
+                        return NetworkDeviceState.FirmwareMismatch;
+                    case 4:
+                        return NetworkDeviceState.Upgrading;
                     case 5:
                         return NetworkDeviceState.Provisioning;
-
+                    case 6:
+                        return NetworkDeviceState.HeartbeatMissed;
+                    case 7:
+                        return NetworkDeviceState.Adopting;
+                    case 8:
+                        return NetworkDeviceState.Deleting;
+                    case 9:
+                        return NetworkDeviceState.Disconnected; // According to the UniFi app, 9 represents disconnecting although this does not reflect real-world testing where 0 = Disconnected.
                     case 10:
                         return NetworkDeviceState.AdoptionFailed;
+                    case 11:
+                        return NetworkDeviceState.Isolated;
                 }
 
                 return NetworkDeviceState.Unknown;


### PR DESCRIPTION
Change rx/tx bytes to long to avoid integer overflow, and add additional states to the NetworkDeviceState enum.