### PR TITLE
Fix reboot device call by using restart command

### DIFF
--- a/UniFiSharp/UniFiApi.NetworkDevices.cs
+++ b/UniFiSharp/UniFiApi.NetworkDevices.cs
@@ -61,7 +61,8 @@ namespace UniFiSharp
         {
             await RestClient.UniFiPost($"api/s/{Site}/cmd/devmgr", new
             {
-                cmd = "reboot",
+                reboot_type = "soft",
+                cmd = "restart",
                 mac = macAddress
             });
         }


### PR DESCRIPTION
The command to reboot or restart a device (api.NetworkDeviceRestart(mac address) is not reboot, but restart. According to the website its calls, a  reboot_type = "soft" is also added. Fixed the NetworkDeviceRestart call with these 2 properties

https://github.com/anthturner/UniFiSharp/issues/14