### PR TITLE
Update RestSharp package to 106.12.0 and minor refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # UniFiSharp
 
+**Original project: https://github.com/anthturner/UniFiSharp**
+
 _Bringing Ubiquiti UniFi Orchestration Automation to C#_
 
 UniFiSharp provides a basic C# API for Ubiquiti UniFi controllers, as well as an orchestration overlay to more easily visualize network topology and execute device commands. UniFiSharp also implements both v1 and v2 of the Ubiquiti discovery protocol for automated controller discovery.

--- a/UniFiSharp/DefaultUniFiRestClient.cs
+++ b/UniFiSharp/DefaultUniFiRestClient.cs
@@ -15,12 +15,15 @@ namespace UniFiSharp
         private string _username, _password, _code;
         private bool _useModernApi;
 
-        internal DefaultUniFiRestClient(Uri baseUrl, string username, string password, string code, bool ignoreSslValidation, bool useModernApi) : 
+        internal DefaultUniFiRestClient(Uri baseUrl, string username, string password, string code,
+            bool ignoreSslValidation, bool useModernApi) :
             this(baseUrl, username, password, ignoreSslValidation, useModernApi)
         {
             _code = code;
         }
-        internal DefaultUniFiRestClient(Uri baseUrl, string username, string password, bool ignoreSslValidation, bool useModernApi) : base(baseUrl)
+
+        internal DefaultUniFiRestClient(Uri baseUrl, string username, string password, bool ignoreSslValidation,
+            bool useModernApi) : base(baseUrl)
         {
             _username = username;
             _password = password;
@@ -97,8 +100,7 @@ namespace UniFiSharp
 
         private async Task UniFiRequest(Method method, string url, object jsonBody = null)
         {
-            var request = new RestRequest(url, method);
-            request.JsonSerializer.ContentType = $"application/json; charset={Encoding.BodyName}";
+            var request = new RestRequest(url, method, DataFormat.Json);
             if ((method == Method.POST || method == Method.PUT) && jsonBody != null)
                 request.AddJsonBody(jsonBody);
             await ExecuteRequest<object>(request);
@@ -106,18 +108,17 @@ namespace UniFiSharp
 
         private async Task<T> UniFiRequest<T>(Method method, string url, object jsonBody = null) where T : new()
         {
-            var request = new RestRequest(url, method);
-            request.JsonSerializer.ContentType = $"application/json; charset={Encoding.BodyName}";
+            var request = new RestRequest(url, method, DataFormat.Json);
             if ((method == Method.POST || method == Method.PUT) && jsonBody != null)
                 request.AddJsonBody(jsonBody);
             var envelope = await ExecuteRequest<T>(request);
             return (envelope.Data == null) ? default(T) : envelope.Data[0];
         }
 
-        private async Task<IList<T>> UniFiRequestMany<T>(Method method, string url, object jsonBody = null) where T : new()
+        private async Task<IList<T>> UniFiRequestMany<T>(Method method, string url, object jsonBody = null)
+            where T : new()
         {
-            var request = new RestRequest(url, method);
-            request.JsonSerializer.ContentType = $"application/json; charset={Encoding.BodyName}";
+            var request = new RestRequest(url, method, DataFormat.Json);
             if ((method == Method.POST || method == Method.PUT) && jsonBody != null)
                 request.AddJsonBody(jsonBody);
             var envelope = await ExecuteRequest<T>(request);
@@ -128,8 +129,7 @@ namespace UniFiSharp
         {
             if (_useModernApi)
             {
-                var request = new RestRequest("api/auth/login", Method.POST);
-                request.JsonSerializer.ContentType = $"application/json; charset={Encoding.BodyName}";
+                var request = new RestRequest("api/auth/login", Method.POST, DataFormat.Json);
                 request.AddJsonBody(new
                 {
                     username = _username,
@@ -157,7 +157,8 @@ namespace UniFiSharp
             }
         }
 
-        private async Task<JsonMessageEnvelope<T>> ExecuteRequest<T>(IRestRequest request, bool attemptReauthentication = true) where T : new()
+        private async Task<JsonMessageEnvelope<T>> ExecuteRequest<T>(IRestRequest request,
+            bool attemptReauthentication = true) where T : new()
         {
             if (_useModernApi)
                 request.Resource = "proxy/network/" + request.Resource;
@@ -167,8 +168,14 @@ namespace UniFiSharp
 
             if (this.CookieContainer.GetCookies(this.BaseUrl).Count > 0)
             {
-                try { this.AddDefaultHeader("X-Csrf-Token", this.CookieContainer.GetCookies(this.BaseUrl)["csrf_token"].Value); }
-                catch { }
+                try
+                {
+                    this.AddDefaultHeader("X-Csrf-Token",
+                        this.CookieContainer.GetCookies(this.BaseUrl)["csrf_token"].Value);
+                }
+                catch
+                {
+                }
             }
 
             request.RequestFormat = DataFormat.Json;
@@ -201,7 +208,8 @@ namespace UniFiSharp
         /// <param name="data"></param>
         /// <param name="attemptReauthentication"></param>
         /// <returns></returns>
-        private async Task UnifiMultipartFormRequest(string url, string name, string fileName, string contentType, byte[] data, bool attemptReauthentication = true)
+        private async Task UnifiMultipartFormRequest(string url, string name, string fileName, string contentType,
+            byte[] data, bool attemptReauthentication = true)
         {
             // Note the UniFi controller will return 404 when uploading a file - however the file *is* successfully uploaded. 
 
@@ -212,8 +220,14 @@ namespace UniFiSharp
 
             if (this.CookieContainer.GetCookies(this.BaseUrl).Count > 0)
             {
-                try { this.AddDefaultHeader("X-Csrf-Token", this.CookieContainer.GetCookies(this.BaseUrl)["csrf_token"].Value); }
-                catch { }
+                try
+                {
+                    this.AddDefaultHeader("X-Csrf-Token",
+                        this.CookieContainer.GetCookies(this.BaseUrl)["csrf_token"].Value);
+                }
+                catch
+                {
+                }
             }
 
             var request = new RestRequest(url, Method.POST)
@@ -238,7 +252,5 @@ namespace UniFiSharp
                 }
             }
         }
-
-
     }
 }

--- a/UniFiSharp/UniFiApi.NetworkDevices.cs
+++ b/UniFiSharp/UniFiApi.NetworkDevices.cs
@@ -90,7 +90,7 @@ namespace UniFiSharp
         {
             await RestClient.UniFiPost($"api/s/{Site}/cmd/sitemgr", new
             {
-                cmd = "delete-device",
+                cmd = "forget-sta", //"delete-device",
                 mac = macAddress
             });
         }

--- a/UniFiSharp/UniFiSharp.csproj
+++ b/UniFiSharp/UniFiSharp.csproj
@@ -32,8 +32,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="RestSharp" Version="106.2.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="RestSharp" Version="106.11.7" />
   </ItemGroup>
 
 </Project>

--- a/UniFiSharp/UniFiSharp.csproj
+++ b/UniFiSharp/UniFiSharp.csproj
@@ -33,7 +33,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="RestSharp" Version="106.11.7" />
+    <PackageReference Include="RestSharp" Version="106.2.2" />
   </ItemGroup>
 
 </Project>

--- a/UniFiSharp/UniFiSharp.csproj
+++ b/UniFiSharp/UniFiSharp.csproj
@@ -33,7 +33,8 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="RestSharp" Version="106.2.2" />
+    <PackageReference Include="RestSharp" Version="106.12.0" />
+    <PackageReference Include="RestSharp.Serializers.NewtonsoftJson" Version="106.12.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
After updating the restSharp package, the rest calls end up in a null reference exception. This is due to expecting the client's JsonSerializer to be set, which it isn't.

```
request.JsonSerializer.ContentType = $"application/json; charset={Encoding.BodyName}";
```

This can be easily fixed with calling the constructor with the dataFormat parameter: 

```
var request = new RestRequest(url, method, DataFormat.Json);
```