### PR TITLE
Fix version, multi-object render in CLI

### DIFF
--- a/UniFiSharp.CLI/Program.cs
+++ b/UniFiSharp.CLI/Program.cs
@@ -6,7 +6,7 @@ namespace UniFiSharp.CLI
 {
     internal class Program
     {
-        private static string Version => "v1.5.0";
+        private static string Version => "v1.5.1";
         internal static bool Quiet { get; private set; } = false;
         internal static CommandApp App { get; private set; } = new CommandApp();
         static void Main(string[] args)

--- a/UniFiSharp.CLI/TableGenerator.cs
+++ b/UniFiSharp.CLI/TableGenerator.cs
@@ -16,7 +16,7 @@ namespace UniFiSharp.CLI
         {
             if (data == null || !data.Any()) return new Text("<No Data>");
 
-            var properties = (data as IJsonObject).GetVisibleProperties(Levels.Minimal);
+            var properties = data.Cast<IJsonObject>().First().GetVisibleProperties(Levels.Minimal);
 
             var tbl = new Table().AddColumns(
                 properties.Select(p => new TableColumn(p.GetPropertyName()))


### PR DESCRIPTION
* Fixes the version displayed in the CLI tool to reflect the matching library, `v1.5.1`.
* Fixes a logic error in CLI tool's multi-object rendering reported by @lkarolj