### PR TITLE
Pull version for CLI from UniFiSharp assembly metadata

### DIFF
--- a/UniFiSharp.CLI/Program.cs
+++ b/UniFiSharp.CLI/Program.cs
@@ -1,20 +1,31 @@
 using Spectre.Console;
 using Spectre.Console.Cli;
+using System.Reflection;
 using UniFiSharp.CLI.Commands;
 
 namespace UniFiSharp.CLI
 {
     internal class Program
     {
-        private static string Version => "v1.5.1";
         internal static bool Quiet { get; private set; } = false;
         internal static CommandApp App { get; private set; } = new CommandApp();
         static void Main(string[] args)
         {
             Console.WriteLine();
 
+            // ---
+            var version = Assembly.GetAssembly(typeof(UniFiApi))?.GetName()?.Version?.ToString(3);
+            version = null;
+            if (version == null)
+            {
+                AnsiConsole.MarkupLine("[red bold]CRITICAL: UniFiSharp library not loaded properly.[/]");
+                return;
+            }
+            // ---
+
+
             if (!args.Any(a => a == "-q" || a == "--quiet"))
-                DrawUniFiSharpLogo();
+                DrawUniFiSharpLogo(version);
             else Quiet = true;
 
             App.Configure(config =>
@@ -177,7 +188,7 @@ namespace UniFiSharp.CLI
             Console.WriteLine();
         }
 
-        private static void DrawUniFiSharpLogo()
+        private static void DrawUniFiSharpLogo(string version)
         {
             var c1 = "[blue]";
             var c2 = "[#666666]";
@@ -188,7 +199,7 @@ namespace UniFiSharp.CLI
 
             AnsiConsole.Write(new Rule().RuleStyle("blue dim"));
             AnsiConsole.MarkupLine($"{c1} __ {e}{c3}   __ {e}{c1}  __ __{e}");
-            AnsiConsole.MarkupLine($"{c1}|  |{e}{c3}  |  |{e}{c1}_/ // /_{e}\t{c1}UniFi Command Line Tool{e} {v}{Version}{e}");
+            AnsiConsole.MarkupLine($"{c1}|  |{e}{c3}  |  |{e}{c1}_/ // /_{e}\t{c1}UniFi Command Line Tool{e} {v}{version}{e}");
             AnsiConsole.MarkupLine($"{c1}|  |{e}{c3}  |  {e}{c1}/_  _  __/{e}\t{l}https://github.com/anthturner/UniFiSharp{e}");
             AnsiConsole.MarkupLine($"{c1}|  |{e}{c3}  | {e}{c1}/_  _  __/{e}");
             AnsiConsole.MarkupLine($"{c1}|  \\{e}{c2}--{e}{c3}^-`{e}{c1}/_//_/{e}\t\t{c2}This tool is not supported or affiliated{e}");

--- a/UniFiSharp.CLI/Program.cs
+++ b/UniFiSharp.CLI/Program.cs
@@ -13,16 +13,12 @@ namespace UniFiSharp.CLI
         {
             Console.WriteLine();
 
-            // ---
             var version = Assembly.GetAssembly(typeof(UniFiApi))?.GetName()?.Version?.ToString(3);
-            version = null;
             if (version == null)
             {
                 AnsiConsole.MarkupLine("[red bold]CRITICAL: UniFiSharp library not loaded properly.[/]");
                 return;
             }
-            // ---
-
 
             if (!args.Any(a => a == "-q" || a == "--quiet"))
                 DrawUniFiSharpLogo(version);

--- a/UniFiSharp/UniFiSharp.csproj
+++ b/UniFiSharp/UniFiSharp.csproj
@@ -3,7 +3,7 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<PackageId>UniFiSharp</PackageId>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-		<Version>1.5.1</Version>
+		<Version>1.5.2</Version>
 		<Authors>Anthony Turner</Authors>
 		<Company>Anthony Turner</Company>
 		<Description>UniFiSharp provides a cross-platform (NETStandard) interface to control and monitor Ubiquiti UniFi networking components via the UniFi controller software.</Description>
@@ -12,8 +12,8 @@
 		<RepositoryUrl>https://github.com/anthturner/UniFiSharp</RepositoryUrl>
 		<RepositoryType>GitHub</RepositoryType>
 		<PackageTags>unifi ubiquiti ubnt</PackageTags>
-		<AssemblyVersion>1.5.1.0</AssemblyVersion>
-		<FileVersion>1.5.1.0</FileVersion>
+		<AssemblyVersion>1.5.2.0</AssemblyVersion>
+		<FileVersion>1.5.2.0</FileVersion>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
 		<PackageIcon>UniFiSharpLogo.png</PackageIcon>
 		<ApplicationIcon>UniFiSharpLogo.ico</ApplicationIcon>


### PR DESCRIPTION
Instead of a static string for the version, the CLI app will pull the version from the UniFiSharp assembly directly (as these two projects should be releasing in sync).

This will become 1.5.2.